### PR TITLE
Feature/refactored

### DIFF
--- a/common/src/main/java/eu/arrowhead/common/api/ArrowheadClient.java
+++ b/common/src/main/java/eu/arrowhead/common/api/ArrowheadClient.java
@@ -5,7 +5,6 @@ import eu.arrowhead.common.api.clients.EventHandlerClient;
 import eu.arrowhead.common.api.clients.ServiceRegistryClient;
 import eu.arrowhead.common.exception.KeystoreException;
 import eu.arrowhead.common.misc.ArrowheadProperties;
-import eu.arrowhead.common.misc.Utility;
 import org.apache.log4j.Logger;
 import org.apache.log4j.PropertyConfigurator;
 
@@ -20,7 +19,7 @@ public abstract class ArrowheadClient {
     private ArrowheadProperties props;
 
     public ArrowheadClient(String[] args) {
-        setProperties(Utility.getProp());
+        setProperties(ArrowheadProperties.loadDefault());
 
         boolean daemon = false;
         for (String arg : args) {

--- a/common/src/main/java/eu/arrowhead/common/api/ArrowheadSecurityContext.java
+++ b/common/src/main/java/eu/arrowhead/common/api/ArrowheadSecurityContext.java
@@ -3,7 +3,6 @@ package eu.arrowhead.common.api;
 import eu.arrowhead.common.exception.KeystoreException;
 import eu.arrowhead.common.misc.ArrowheadProperties;
 import eu.arrowhead.common.misc.SecurityUtils;
-import eu.arrowhead.common.misc.Utility;
 import org.apache.log4j.Logger;
 import org.glassfish.grizzly.ssl.SSLContextConfigurator;
 
@@ -19,7 +18,7 @@ public class ArrowheadSecurityContext {
     private SSLContextConfigurator sslContextConfigurator;
 
     public static ArrowheadSecurityContext createFromProperties() throws KeystoreException {
-        return createFromProperties(Utility.getProp());
+        return createFromProperties(ArrowheadProperties.loadDefault());
     }
 
     public static ArrowheadSecurityContext createFromProperties(ArrowheadProperties props) throws KeystoreException {

--- a/common/src/main/java/eu/arrowhead/common/api/ArrowheadServer.java
+++ b/common/src/main/java/eu/arrowhead/common/api/ArrowheadServer.java
@@ -34,7 +34,7 @@ public class ArrowheadServer {
     private ArrowheadSecurityContext securityContext;
 
     public static ArrowheadServer createFromProperties(ArrowheadSecurityContext securityContext) {
-        return createFromProperties(Utility.getProp(), securityContext);
+        return createFromProperties(ArrowheadProperties.loadDefault(), securityContext);
     }
 
     public static ArrowheadServer createFromProperties(ArrowheadProperties props, ArrowheadSecurityContext securityContext) {

--- a/common/src/main/java/eu/arrowhead/common/api/clients/CertificateAuthorityClient.java
+++ b/common/src/main/java/eu/arrowhead/common/api/clients/CertificateAuthorityClient.java
@@ -18,8 +18,6 @@ import java.security.KeyPair;
 import java.security.KeyStore;
 import java.security.PublicKey;
 import java.security.Security;
-import java.util.HashMap;
-import java.util.Map;
 
 public final class CertificateAuthorityClient extends RestClient {
     private String keyPass, truststore, truststorePass, keystorePass;
@@ -35,7 +33,6 @@ public final class CertificateAuthorityClient extends RestClient {
     }
 
     public static CertificateAuthorityClient createFromProperties(ArrowheadProperties props) {
-        final boolean isSecure = props.isSecure();
         return new CertificateAuthorityClient()
                 .setAddress(props.getCaAddress())
                 .setPort(props.getCaPort())
@@ -188,16 +185,17 @@ public final class CertificateAuthorityClient extends RestClient {
         }
 
         // Update app.conf with the new values
-        Map<String, String> secureParameters = new HashMap<>();
-        secureParameters.put("keystore", newKeystore);
-        secureParameters.put("keystorepass", keyStorePassword);
-        secureParameters.put("keypass", keyStorePassword);
-        secureParameters.put("truststore", newTruststore);
-        secureParameters.put("truststorepass", trustStorePassword);
+        final ArrowheadProperties props = ArrowheadProperties
+                .load(confDir + File.separator + "app.conf")
+                .setKeystore(newKeystore)
+                .setKeystorePass(keyStorePassword)
+                .setKeyPass(keyStorePassword)
+                .setTruststore(newTruststore)
+                .setTruststorePass(trustStorePassword);
         if (needAuth) {
-            secureParameters.put("auth_pub", authFile);
+            props.setAuthKey(authFile);
         }
-        ArrowheadProperties.updateConfigurationFiles(confDir + File.separator + "app.conf", secureParameters);
+        props.storeToFile(confDir + File.separator + "app.conf");
 
         try {
             return ArrowheadSecurityContext.create(newKeystore, keyStorePassword, keyStorePassword, newTruststore, truststorePass);

--- a/common/src/main/java/eu/arrowhead/common/api/clients/CertificateAuthorityClient.java
+++ b/common/src/main/java/eu/arrowhead/common/api/clients/CertificateAuthorityClient.java
@@ -31,7 +31,7 @@ public final class CertificateAuthorityClient extends RestClient {
     }
 
     public static CertificateAuthorityClient createFromProperties() {
-        return createFromProperties(Utility.getProp());
+        return createFromProperties(ArrowheadProperties.loadDefault());
     }
 
     public static CertificateAuthorityClient createFromProperties(ArrowheadProperties props) {
@@ -197,7 +197,7 @@ public final class CertificateAuthorityClient extends RestClient {
         if (needAuth) {
             secureParameters.put("auth_pub", authFile);
         }
-        Utility.updateConfigurationFiles(confDir + File.separator + "app.conf", secureParameters);
+        ArrowheadProperties.updateConfigurationFiles(confDir + File.separator + "app.conf", secureParameters);
 
         try {
             return ArrowheadSecurityContext.create(newKeystore, keyStorePassword, keyStorePassword, newTruststore, truststorePass);

--- a/common/src/main/java/eu/arrowhead/common/api/clients/EventHandlerClient.java
+++ b/common/src/main/java/eu/arrowhead/common/api/clients/EventHandlerClient.java
@@ -3,7 +3,6 @@ package eu.arrowhead.common.api.clients;
 import eu.arrowhead.common.api.ArrowheadSecurityContext;
 import eu.arrowhead.common.exception.ArrowheadRuntimeException;
 import eu.arrowhead.common.misc.ArrowheadProperties;
-import eu.arrowhead.common.misc.Utility;
 import eu.arrowhead.common.model.ArrowheadSystem;
 import eu.arrowhead.common.model.Event;
 import eu.arrowhead.common.model.EventFilter;
@@ -19,7 +18,7 @@ public class EventHandlerClient extends RestClient {
     private static final Map<EventHandlerClient, Map<ArrowheadSystem, Set<String>>> subscriptions = new HashMap<>();
 
     public static EventHandlerClient createFromProperties(ArrowheadSecurityContext securityContext) {
-        return createFromProperties(Utility.getProp(), securityContext);
+        return createFromProperties(ArrowheadProperties.loadDefault(), securityContext);
     }
 
     public static EventHandlerClient createFromProperties(ArrowheadProperties props, ArrowheadSecurityContext securityContext) {
@@ -71,7 +70,7 @@ public class EventHandlerClient extends RestClient {
     }
 
     public void subscribe(String eventType, ArrowheadSystem consumer) {
-        subscribe(eventType, consumer, Utility.getProp());
+        subscribe(eventType, consumer, ArrowheadProperties.loadDefault());
     }
 
     public void subscribe(String eventType, ArrowheadSystem consumer, ArrowheadProperties props) {

--- a/common/src/main/java/eu/arrowhead/common/api/clients/OrchestrationClient.java
+++ b/common/src/main/java/eu/arrowhead/common/api/clients/OrchestrationClient.java
@@ -9,7 +9,7 @@ import javax.ws.rs.core.UriBuilder;
 
 public class OrchestrationClient extends RestClient {
     public static OrchestrationClient createFromProperties(ArrowheadSecurityContext securityContext) {
-        return createFromProperties(Utility.getProp(), securityContext);
+        return createFromProperties(ArrowheadProperties.loadDefault(), securityContext);
     }
 
     public static OrchestrationClient createFromProperties(ArrowheadProperties props, ArrowheadSecurityContext securityContext) {

--- a/common/src/main/java/eu/arrowhead/common/api/clients/ServiceRegistryClient.java
+++ b/common/src/main/java/eu/arrowhead/common/api/clients/ServiceRegistryClient.java
@@ -4,7 +4,6 @@ import eu.arrowhead.common.api.ArrowheadSecurityContext;
 import eu.arrowhead.common.exception.ArrowheadRuntimeException;
 import eu.arrowhead.common.exception.ExceptionType;
 import eu.arrowhead.common.misc.ArrowheadProperties;
-import eu.arrowhead.common.misc.Utility;
 import eu.arrowhead.common.model.ServiceRegistryEntry;
 
 import java.util.*;
@@ -13,7 +12,7 @@ public class ServiceRegistryClient extends RestClient {
     private static final Map<ServiceRegistryClient, Set<ServiceRegistryEntry>> entries = new HashMap<>();
 
     public static ServiceRegistryClient createFromProperties(ArrowheadSecurityContext securityContext) {
-        return createFromProperties(Utility.getProp(), securityContext);
+        return createFromProperties(ArrowheadProperties.loadDefault(), securityContext);
     }
 
     public static ServiceRegistryClient createFromProperties(ArrowheadProperties props, ArrowheadSecurityContext securityContext) {

--- a/common/src/main/java/eu/arrowhead/common/misc/ArrowheadProperties.java
+++ b/common/src/main/java/eu/arrowhead/common/misc/ArrowheadProperties.java
@@ -14,6 +14,49 @@ import java.time.ZonedDateTime;
 import java.util.*;
 
 public class ArrowheadProperties extends TypeSafeProperties {
+
+
+
+    private enum Keys {
+        SECURE("secure"),
+        KEYSTORE("keystore"),
+        KEYSTOREPASS("keystorepass"),
+        KEYPASS("keypass"),
+        TRUSTSTORE("truststore"),
+        TRUSTSTOREPASS("truststorepass"),
+        SYSTEM_NAME("system_name"),
+        ADDRESS("address"),
+        PORT("port"),
+        SR_ADDRESS("sr_address"),
+        SR_PORT("sr_port"),
+        ORCH_ADDRESS("orch_address"),
+        ORCH_PORT("orch_port"),
+        EH_ADDRESS("eh_address"),
+        EH_PORT("eh_port"),
+        CA_ADDRESS("ca_address"),
+        CA_PORT("ca_port"),
+        AUTH_PUB("auth_pub"),
+        SERVICE_URI("service_uri"),
+        SERVICE_NAME("service_name"),
+        INTERFACES("interfaces"),
+        SERVICE_METADATA("service_metadata"),
+        EVENT_TYPE("event_type"),
+        NOTIFY_URI("notify_uri"),
+        CERT_DIR("cert_dir"),
+        BOOTSTRAP("bootstrap"),
+        ;
+        private final String key;
+
+        Keys(final String key) {
+            this.key = key;
+        }
+
+        @Override
+        public String toString() {
+            return key;
+        }
+
+    }
     public static String getConfDir() {
         return System.getProperty("confDir");
     }
@@ -109,91 +152,141 @@ public class ArrowheadProperties extends TypeSafeProperties {
         return prop;
     }
 
+    private int getIntProperty(Keys key, int defaultValue) {
+        return super.getIntProperty(key.toString(), defaultValue);
+    }
+
+    private boolean getBooleanProperty(Keys key, boolean defaultValue) {
+        return super.getBooleanProperty(key.toString(), defaultValue);
+    }
+
+    private String getProperty(Keys key) {
+        return super.getProperty(key.toString());
+    }
+
+    private String getProperty(Keys key, String defaultValue) {
+        return super.getProperty(key.toString(), defaultValue);
+    }
+
+    private synchronized Object setProperty(Keys key, String value) {
+        return super.setProperty(key.toString(), value);
+    }
+
     public boolean isSecure() {
-        return getBooleanProperty("secure", getDefaultIsSecure());
+        return getBooleanProperty(Keys.SECURE, getDefaultIsSecure());
     }
 
     public String getKeystore() {
         final String certDir = getCertDir();
-        return (certDir != null ? certDir + File.separator : "") + getProperty("keystore", getDefaultKeyStore(getSystemName()));
+        return (certDir != null ? certDir + File.separator : "") + getProperty(Keys.KEYSTORE, getDefaultKeyStore(getSystemName()));
+    }
+
+    public ArrowheadProperties setKeystore(String keystore) {
+        setProperty(Keys.KEYSTORE, keystore);
+        return this;
     }
 
     public String getKeystorePass() {
-        return getProperty("keystorepass");
+        return getProperty(Keys.KEYSTOREPASS);
+    }
+
+    public ArrowheadProperties setKeystorePass(String keystorePass) {
+        setProperty(Keys.KEYSTOREPASS, keystorePass);
+        return this;
     }
 
     public String getKeyPass() {
-        return getProperty("keypass");
+        return getProperty(Keys.KEYPASS);
+    }
+
+    public ArrowheadProperties setKeyPass(String keyPass) {
+        setProperty(Keys.KEYPASS, keyPass);
+        return this;
     }
 
     public String getTruststore() {
         final String certDir = getCertDir();
-        return (certDir != null ? certDir + File.separator : "") + getProperty("truststore", getDefaultTruststore(getSystemName()));
+        return (certDir != null ? certDir + File.separator : "") + getProperty(Keys.TRUSTSTORE, getDefaultTruststore(getSystemName()));
+    }
+
+    public ArrowheadProperties setTruststore(String truststore) {
+        setProperty(Keys.TRUSTSTORE, truststore);
+        return this;
     }
 
     public String getTruststorePass() {
-        return getProperty("truststorepass");
+        return getProperty(Keys.TRUSTSTOREPASS);
+    }
+
+    public ArrowheadProperties setTruststorePass(String truststorePass) {
+        setProperty(Keys.TRUSTSTOREPASS, truststorePass);
+        return this;
     }
 
     public String getSystemName() {
-        return getProperty("system_name");
+        return getProperty(Keys.SYSTEM_NAME);
     }
 
     public String getAddress() {
-        return getProperty("address", getDefaultAddress());
+        return getProperty(Keys.ADDRESS, getDefaultAddress());
     }
 
     public int getPort() {
-        return getIntProperty("port", getDefaultPort(isSecure()));
+        return getIntProperty(Keys.PORT, getDefaultPort(isSecure()));
     }
 
     public String getSrAddress() {
-        return getProperty("sr_address", getDefaultSrAddress());
+        return getProperty(Keys.SR_ADDRESS, getDefaultSrAddress());
     }
 
     public int getSrPort() {
-        return getIntProperty("sr_port", getDefaultSrPort(isSecure()));
+        return getIntProperty(Keys.SR_PORT, getDefaultSrPort(isSecure()));
     }
 
     public String getOrchAddress() {
-        return getProperty("orch_address", getDefaultOrchAddress());
+        return getProperty(Keys.ORCH_ADDRESS, getDefaultOrchAddress());
     }
 
     public int getOrchPort() {
-        return getIntProperty("orch_port", getDefaultOrchPort(isSecure()));
+        return getIntProperty(Keys.ORCH_PORT, getDefaultOrchPort(isSecure()));
     }
 
     public String getEhAddress() {
-        return getProperty("eh_address", getDefaultEhAddress());
+        return getProperty(Keys.EH_ADDRESS, getDefaultEhAddress());
     }
 
     public int getEhPort() {
-        return getIntProperty("eh_port", getDefaultEhPort(isSecure()));
+        return getIntProperty(Keys.EH_PORT, getDefaultEhPort(isSecure()));
     }
 
     public String getCaAddress() {
-        return getProperty("ca_address", getDefaultCaAddress());
+        return getProperty(Keys.CA_ADDRESS, getDefaultCaAddress());
     }
 
     public int getCaPort() {
-        return getIntProperty("ca_port", getDefaultCaPort(isSecure()));
+        return getIntProperty(Keys.CA_PORT, getDefaultCaPort(isSecure()));
     }
 
     public String getAuthKey() {
         final String certDir = getCertDir();
-        return (certDir != null ? certDir + File.separator : "") + getProperty("auth_pub", getDefaultAuthKey());
+        return (certDir != null ? certDir + File.separator : "") + getProperty(Keys.AUTH_PUB, getDefaultAuthKey());
+    }
+
+    public ArrowheadProperties setAuthKey(String authKey) {
+        setProperty(Keys.AUTH_PUB, authKey);
+        return this;
     }
 
     public String getServiceUri() {
-        return getProperty("service_uri");
+        return getProperty(Keys.SERVICE_URI);
     }
 
     public String getServiceName() {
-        return getProperty("service_name");
+        return getProperty(Keys.SERVICE_NAME);
     }
 
     public Set<String> getInterfaces() {
-        String interfaceList = getProperty("interfaces");
+        String interfaceList = getProperty(Keys.INTERFACES);
         Set<String> interfaces = new HashSet<>();
         if (interfaceList != null && !interfaceList.isEmpty()) {
             interfaces.addAll(Arrays.asList(interfaceList.replaceAll("\\s+", "").split(",")));
@@ -203,7 +296,7 @@ public class ArrowheadProperties extends TypeSafeProperties {
 
     public ServiceMetadata getServiceMetadata() {
         ServiceMetadata metadata = new ServiceMetadata();
-        String metadataString = getProperty("service_metadata");
+        String metadataString = getProperty(Keys.SERVICE_METADATA);
         if (metadataString != null && !metadataString.isEmpty()) {
             String[] parts = metadataString.split(",");
             for (String part : parts) {
@@ -215,19 +308,19 @@ public class ArrowheadProperties extends TypeSafeProperties {
     }
 
     public String getEventType() {
-        return getProperty("event_type");
+        return getProperty(Keys.EVENT_TYPE);
     }
 
     public String getNotifyUri() {
-        return getProperty("notify_uri", getDefaultNotifyUri());
+        return getProperty(Keys.NOTIFY_URI, getDefaultNotifyUri());
     }
 
     public String getCertDir() {
-        return getProperty("cert_dir", getDefaultCertDir());
+        return getProperty(Keys.CERT_DIR, getDefaultCertDir());
     }
 
     public boolean isBootstrap() {
-        return getBooleanProperty("bootstrap", getDefaultBootstrap());
+        return getBooleanProperty(Keys.BOOTSTRAP, getDefaultBootstrap());
     }
 
     public void checkProperties(List<String> mandatoryProperties) {
@@ -245,30 +338,4 @@ public class ArrowheadProperties extends TypeSafeProperties {
         }
     }
 
-    /**
-     Updates the given properties file with the given key-value pairs.
-     */
-    public static void updateConfigurationFiles(String configLocation, Map<String, String> configValues) {
-        try {
-            final Path path = Paths.get(configLocation);
-            ArrowheadProperties props = new ArrowheadProperties();
-
-            if (Files.exists(path)) {
-                FileInputStream in = new FileInputStream(configLocation);
-                props.load(in);
-                in.close();
-            } else {
-                Files.createFile(path);
-            }
-
-            FileOutputStream out = new FileOutputStream(configLocation);
-            for (Map.Entry<String, String> entry : configValues.entrySet()) {
-                props.setProperty(entry.getKey(), entry.getValue());
-            }
-            props.store(out, null);
-            out.close();
-        } catch (IOException e) {
-            throw new ArrowheadRuntimeException("IOException during configuration file update", e);
-        }
-    }
 }

--- a/common/src/main/java/eu/arrowhead/common/misc/ArrowheadProperties.java
+++ b/common/src/main/java/eu/arrowhead/common/misc/ArrowheadProperties.java
@@ -81,6 +81,10 @@ public class ArrowheadProperties extends TypeSafeProperties {
         return "config/certificates";
     }
 
+    public static boolean getDefaultBootstrap() {
+        return false;
+    }
+
     public boolean isSecure() {
         return getBooleanProperty("secure", getDefaultIsSecure());
     }
@@ -196,5 +200,9 @@ public class ArrowheadProperties extends TypeSafeProperties {
 
     public String getCertDir() {
         return getProperty("cert_dir", getDefaultCertDir());
+    }
+
+    public boolean isBootstrap() {
+        return getBooleanProperty("bootstrap", getDefaultBootstrap());
     }
 }

--- a/common/src/main/java/eu/arrowhead/common/misc/SecurityVerifier.java
+++ b/common/src/main/java/eu/arrowhead/common/misc/SecurityVerifier.java
@@ -21,7 +21,7 @@ public class SecurityVerifier {
     private PublicKey authKey;
 
     public static SecurityVerifier createFromProperties() {
-        return createFromProperties(Utility.getProp());
+        return createFromProperties(ArrowheadProperties.loadDefault());
     }
 
     public static SecurityVerifier createFromProperties(ArrowheadProperties props) {

--- a/common/src/main/java/eu/arrowhead/common/misc/TypeSafeProperties.java
+++ b/common/src/main/java/eu/arrowhead/common/misc/TypeSafeProperties.java
@@ -9,12 +9,13 @@
 
 package eu.arrowhead.common.misc;
 
+import eu.arrowhead.common.exception.ArrowheadRuntimeException;
 import org.apache.log4j.Logger;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.Map.Entry;
 
@@ -33,6 +34,24 @@ public class TypeSafeProperties extends Properties {
     }
   }
 
+    /**
+     Updates the given properties file with the given key-value pairs.
+     */
+    public void storeToFile(String file) {
+        try {
+            final Path path = Paths.get(file);
+            if (!Files.exists(path)) {
+                Files.createFile(path);
+            }
+
+            FileOutputStream out = new FileOutputStream(file);
+            store(out, null);
+            out.close();
+        } catch (IOException e) {
+            throw new ArrowheadRuntimeException("IOException during configuration file update", e);
+        }
+    }
+
   public int getIntProperty(String key, int defaultValue) {
     String val = getProperty(key);
     try {
@@ -47,8 +66,8 @@ public class TypeSafeProperties extends Properties {
     String val = getProperty(key);
     return (val == null) ? defaultValue : Boolean.valueOf(val);
   }
+    //These methods are here to make sure TypeSafeProperties are saved to file in alphabetical order (sorted by key value)
 
-  //These methods are here to make sure TypeSafeProperties are saved to file in alphabetical order (sorted by key value)
   @Override
   public Set<Object> keySet() {
     return Collections.unmodifiableSet(new TreeSet<>(super.keySet()));

--- a/common/src/main/java/eu/arrowhead/common/misc/Utility.java
+++ b/common/src/main/java/eu/arrowhead/common/misc/Utility.java
@@ -147,37 +147,6 @@ public final class Utility {
         }
     }
 
-    public static ArrowheadProperties getProp(String fileName) {
-        ArrowheadProperties prop = new ArrowheadProperties();
-        prop.loadFromFile(fileName);
-        return prop;
-    }
-
-    public static ArrowheadProperties getProp() {
-        final String confDir = ArrowheadProperties.getConfDir();
-
-        ArrowheadProperties prop = new ArrowheadProperties();
-        prop.loadFromFile((confDir != null ? confDir + File.separator : "") + "default.conf");
-        final String appConf = (confDir != null ? confDir + File.separator : "") + "app.conf";
-        if (Files.isReadable(Paths.get(appConf))) {
-            prop.loadFromFile(appConf);
-        }
-
-        return prop;
-    }
-
-    public static void checkProperties(Set<String> propertyNames, List<String> mandatoryProperties) {
-        if (mandatoryProperties == null || mandatoryProperties.isEmpty()) {
-            return;
-        }
-        //Arrays.asList() returns immutable lists, so we have to copy it first
-        List<String> properties = new ArrayList<>(mandatoryProperties);
-        if (!propertyNames.containsAll(mandatoryProperties)) {
-            properties.removeIf(propertyNames::contains);
-            throw new ServiceConfigurationError("Missing field(s) from config file: " + properties.toString());
-        }
-    }
-
     public static boolean isHostAvailable(String host, int port, int timeout) {
         try (Socket socket = new Socket()) {
             socket.connect(new InetSocketAddress(host, port), timeout);
@@ -196,30 +165,4 @@ public final class Utility {
         return (str == null || "".equals(str.trim()));
     }
 
-    /**
-     Updates the given properties file with the given key-value pairs.
-     */
-    public static void updateConfigurationFiles(String configLocation, Map<String, String> configValues) {
-        try {
-            final Path path = Paths.get(configLocation);
-            ArrowheadProperties props = new ArrowheadProperties();
-
-            if (Files.exists(path)) {
-                FileInputStream in = new FileInputStream(configLocation);
-                props.load(in);
-                in.close();
-            } else {
-                Files.createFile(path);
-            }
-
-            FileOutputStream out = new FileOutputStream(configLocation);
-            for (Map.Entry<String, String> entry : configValues.entrySet()) {
-                props.setProperty(entry.getKey(), entry.getValue());
-            }
-            props.store(out, null);
-            out.close();
-        } catch (IOException e) {
-            throw new ArrowheadRuntimeException("IOException during configuration file update", e);
-        }
-    }
 }

--- a/common/src/main/java/eu/arrowhead/common/model/ArrowheadService.java
+++ b/common/src/main/java/eu/arrowhead/common/model/ArrowheadService.java
@@ -22,7 +22,7 @@ public class ArrowheadService {
     private ServiceMetadata serviceMetadata = new ServiceMetadata();
 
     public static ArrowheadService createFromProperties() {
-        return createFromProperties(Utility.getProp());
+        return createFromProperties(ArrowheadProperties.loadDefault());
     }
 
     public static ArrowheadService createFromProperties(ArrowheadProperties props) {

--- a/common/src/main/java/eu/arrowhead/common/model/ArrowheadSystem.java
+++ b/common/src/main/java/eu/arrowhead/common/model/ArrowheadSystem.java
@@ -12,7 +12,6 @@ package eu.arrowhead.common.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import eu.arrowhead.common.api.ArrowheadServer;
 import eu.arrowhead.common.misc.ArrowheadProperties;
-import eu.arrowhead.common.misc.Utility;
 import org.apache.log4j.Logger;
 
 import java.net.URI;
@@ -28,15 +27,15 @@ public class ArrowheadSystem {
     private String authenticationInfo;
 
     public static ArrowheadSystem createFromProperties(ArrowheadServer server) {
-        return createFromProperties(Utility.getProp(), server);
+        return createFromProperties(ArrowheadProperties.loadDefault(), server);
     }
 
     public static ArrowheadSystem createFromProperties() {
-        return createFromProperties(Utility.getProp(), null);
+        return createFromProperties(ArrowheadProperties.loadDefault(), null);
     }
 
     public static ArrowheadSystem createFromProperties(ArrowheadProperties props) {
-        return createFromProperties(Utility.getProp(), null);
+        return createFromProperties(ArrowheadProperties.loadDefault(), null);
     }
 
     public static ArrowheadSystem createFromProperties(ArrowheadProperties props, ArrowheadServer server) {

--- a/common/src/main/java/eu/arrowhead/common/model/ServiceRegistryEntry.java
+++ b/common/src/main/java/eu/arrowhead/common/model/ServiceRegistryEntry.java
@@ -11,7 +11,6 @@ package eu.arrowhead.common.model;
 
 import eu.arrowhead.common.api.ArrowheadServer;
 import eu.arrowhead.common.misc.ArrowheadProperties;
-import eu.arrowhead.common.misc.Utility;
 
 import java.time.LocalDateTime;
 
@@ -26,7 +25,7 @@ public class ServiceRegistryEntry {
   private Integer version = 1;
 
   public static ServiceRegistryEntry createFromProperties(ArrowheadServer server) {
-    return createFromProperties(Utility.getProp(), server);
+    return createFromProperties(ArrowheadProperties.loadDefault(), server);
   }
 
   private static ServiceRegistryEntry createFromProperties(ArrowheadProperties props, ArrowheadServer server) {

--- a/consumer/config/default.conf
+++ b/consumer/config/default.conf
@@ -10,6 +10,7 @@ port=8008
 system_name=consumer-demo
 
 # Key and trust stores
+bootstrap=true
 truststore=cloud_truststore.p12
 truststorepass=12345
 keypass=12345

--- a/consumer/src/main/java/eu/arrowhead/demo/consumer/ConsumerMain.java
+++ b/consumer/src/main/java/eu/arrowhead/demo/consumer/ConsumerMain.java
@@ -11,10 +11,8 @@ package eu.arrowhead.demo.consumer;
 
 import eu.arrowhead.common.api.ArrowheadClient;
 import eu.arrowhead.common.api.ArrowheadSecurityContext;
-import eu.arrowhead.common.api.clients.CertificateAuthorityClient;
 import eu.arrowhead.common.api.clients.OrchestrationClient;
 import eu.arrowhead.common.api.clients.RestClient;
-import eu.arrowhead.common.exception.KeystoreException;
 import eu.arrowhead.common.misc.Utility;
 import eu.arrowhead.common.model.*;
 import eu.arrowhead.demo.model.TemperatureReadout;
@@ -24,21 +22,15 @@ import javax.ws.rs.core.Response;
 class ConsumerMain extends ArrowheadClient {
 
     public static void main(String[] args) {
-        new ConsumerMain(args);
+        new ConsumerMain(args).start();
     }
 
-    private ConsumerMain(String[] args) {
+    public ConsumerMain(String[] args) {
         super(args);
+    }
 
-        ArrowheadSecurityContext securityContext = null;
-        if (props.isSecure()) {
-            try {
-                securityContext = ArrowheadSecurityContext.createFromProperties();
-            } catch (KeystoreException e) {
-                securityContext = CertificateAuthorityClient.createFromProperties().bootstrap(true);
-            }
-        }
-
+    @Override
+    protected void onStart(ArrowheadSecurityContext securityContext) {
         final OrchestrationClient orchestration = OrchestrationClient.createFromProperties(securityContext);
 
         final ArrowheadSystem me = ArrowheadSystem.createFromProperties();
@@ -62,6 +54,11 @@ class ConsumerMain extends ArrowheadClient {
         } else {
             log.info("The indoor temperature is " + readout.getE().get(0).getV() + " degrees celsius.");
         }
+    }
+
+    @Override
+    protected void onStop() {
+
     }
 
     private ServiceRequestForm compileSRF(ArrowheadSystem consumer) {

--- a/consumer/src/main/java/eu/arrowhead/demo/consumer/ConsumerMain.java
+++ b/consumer/src/main/java/eu/arrowhead/demo/consumer/ConsumerMain.java
@@ -64,7 +64,7 @@ class ConsumerMain extends ArrowheadClient {
     private ServiceRequestForm compileSRF(ArrowheadSystem consumer) {
         final ServiceMetadata metadata = new ServiceMetadata();
         metadata.put(ServiceMetadata.Keys.UNIT, "celsius");
-        if (props.isSecure()) metadata.setSecurity(ServiceMetadata.Security.TOKEN);
+        if (isSecure()) metadata.setSecurity(ServiceMetadata.Security.TOKEN);
 
         final ArrowheadService service = new ArrowheadService("temperature", "json", metadata);
 

--- a/provider/config/default.conf
+++ b/provider/config/default.conf
@@ -14,6 +14,7 @@ interfaces=JSON, XML
 service_metadata=unit-celsius
 
 # Key and trust stores
+bootstrap=true
 truststore=cloud_truststore.p12
 truststorepass=12345
 keypass=12345

--- a/provider/src/main/java/eu/arrowhead/demo/provider/ProviderMain.java
+++ b/provider/src/main/java/eu/arrowhead/demo/provider/ProviderMain.java
@@ -3,29 +3,21 @@ package eu.arrowhead.demo.provider;
 import eu.arrowhead.common.api.ArrowheadClient;
 import eu.arrowhead.common.api.ArrowheadServer;
 import eu.arrowhead.common.api.ArrowheadSecurityContext;
-import eu.arrowhead.common.api.clients.CertificateAuthorityClient;
 import eu.arrowhead.common.api.clients.ServiceRegistryClient;
-import eu.arrowhead.common.exception.KeystoreException;
 import eu.arrowhead.common.model.ServiceRegistryEntry;
 
 class ProviderMain extends ArrowheadClient {
 
   public static void main(String[] args) {
-    new ProviderMain(args);
+    new ProviderMain(args).start();
   }
 
-  private ProviderMain(String[] args) {
+  public ProviderMain(String[] args) {
     super(args);
+  }
 
-    ArrowheadSecurityContext securityContext = null;
-    if (props.isSecure()) {
-      try {
-        securityContext = ArrowheadSecurityContext.createFromProperties();
-      } catch (KeystoreException e) {
-        securityContext = CertificateAuthorityClient.createFromProperties().bootstrap(true);
-      }
-    }
-
+  @Override
+  protected void onStart(ArrowheadSecurityContext securityContext) {
     final ArrowheadServer server = ArrowheadServer.createFromProperties(securityContext);
     server.start(
             new Class[] { TemperatureResource.class, RestResource.class },
@@ -34,8 +26,11 @@ class ProviderMain extends ArrowheadClient {
 
     final ServiceRegistryClient registry = ServiceRegistryClient.createFromProperties(securityContext);
     registry.register(ServiceRegistryEntry.createFromProperties(server));
+  }
 
-    listenForInput();
+  @Override
+  protected void onStop() {
+    
   }
 
 }

--- a/publisher/config/default.conf
+++ b/publisher/config/default.conf
@@ -10,6 +10,7 @@ port=8078
 system_name=publisher-demo
 
 # Key and trust stores
+bootstrap=true
 truststore=cloud_truststore.p12
 truststorepass=12345
 keypass=12345

--- a/publisher/src/main/java/eu/arrowhead/client/publisher/PublisherMain.java
+++ b/publisher/src/main/java/eu/arrowhead/client/publisher/PublisherMain.java
@@ -12,9 +12,7 @@ package eu.arrowhead.client.publisher;
 import eu.arrowhead.common.api.ArrowheadClient;
 import eu.arrowhead.common.api.ArrowheadSecurityContext;
 import eu.arrowhead.common.api.ArrowheadServer;
-import eu.arrowhead.common.api.clients.CertificateAuthorityClient;
 import eu.arrowhead.common.api.clients.EventHandlerClient;
-import eu.arrowhead.common.exception.KeystoreException;
 import eu.arrowhead.common.model.ArrowheadSystem;
 import eu.arrowhead.common.model.Event;
 
@@ -23,21 +21,15 @@ import java.util.*;
 class PublisherMain extends ArrowheadClient {
 
   public static void main(String[] args) {
-    new PublisherMain(args);
+    new PublisherMain(args).start();
   }
 
   private PublisherMain(String[] args) {
     super(args);
+  }
 
-    ArrowheadSecurityContext securityContext = null;
-    if (props.isSecure()) {
-      try {
-        securityContext = ArrowheadSecurityContext.createFromProperties();
-      } catch (KeystoreException e) {
-        securityContext = CertificateAuthorityClient.createFromProperties().bootstrap(true);
-      }
-    }
-
+  @Override
+  protected void onStart(ArrowheadSecurityContext securityContext) {
     final ArrowheadServer server = ArrowheadServer.createFromProperties(securityContext);
     server.start(new Class[] { PublisherResource.class });
 
@@ -52,8 +44,11 @@ class PublisherMain extends ArrowheadClient {
       }
     };
     timer.schedule(authTask, 2L * 1000L, 8L * 1000L);
+  }
 
-    listenForInput();
+  @Override
+  protected void onStop() {
+
   }
 
 }

--- a/publisher/src/main/java/eu/arrowhead/client/publisher/PublisherMain.java
+++ b/publisher/src/main/java/eu/arrowhead/client/publisher/PublisherMain.java
@@ -36,11 +36,12 @@ class PublisherMain extends ArrowheadClient {
     final ArrowheadSystem me = ArrowheadSystem.createFromProperties(server);
 
     final EventHandlerClient eventHandler = EventHandlerClient.createFromProperties(securityContext);
+    final String eventType = getProps().getEventType();
     Timer timer = new Timer();
     TimerTask authTask = new TimerTask() {
       @Override
       public void run() {
-        eventHandler.publish(new Event(props.getEventType(), "Hello World"), me);
+        eventHandler.publish(new Event(eventType, "Hello World"), me);
       }
     };
     timer.schedule(authTask, 2L * 1000L, 8L * 1000L);

--- a/subscriber/config/default.conf
+++ b/subscriber/config/default.conf
@@ -10,6 +10,7 @@ port=8079
 system_name=subscriber-demo
 
 # Key and trust stores
+bootstrap=true
 truststore=cloud_truststore.p12
 truststorepass=12345
 keypass=12345

--- a/subscriber/src/main/java/eu/arrowhead/client/subscriber/SubscriberMain.java
+++ b/subscriber/src/main/java/eu/arrowhead/client/subscriber/SubscriberMain.java
@@ -33,7 +33,7 @@ class SubscriberMain extends ArrowheadClient {
     final ArrowheadSystem me = ArrowheadSystem.createFromProperties(server);
 
     final EventHandlerClient eventHandler = EventHandlerClient.createFromProperties(securityContext);
-    eventHandler.subscribe(props.getEventType(), me);
+    eventHandler.subscribe(getProps().getEventType(), me);
   }
 
   @Override

--- a/subscriber/src/main/java/eu/arrowhead/client/subscriber/SubscriberMain.java
+++ b/subscriber/src/main/java/eu/arrowhead/client/subscriber/SubscriberMain.java
@@ -12,29 +12,21 @@ package eu.arrowhead.client.subscriber;
 import eu.arrowhead.common.api.ArrowheadClient;
 import eu.arrowhead.common.api.ArrowheadSecurityContext;
 import eu.arrowhead.common.api.ArrowheadServer;
-import eu.arrowhead.common.api.clients.CertificateAuthorityClient;
 import eu.arrowhead.common.api.clients.EventHandlerClient;
-import eu.arrowhead.common.exception.KeystoreException;
 import eu.arrowhead.common.model.ArrowheadSystem;
 
 class SubscriberMain extends ArrowheadClient {
 
   public static void main(String[] args) {
-    new SubscriberMain(args);
+    new SubscriberMain(args).start();
   }
 
   private SubscriberMain(String[] args) {
     super(args);
+  }
 
-    ArrowheadSecurityContext securityContext = null;
-    if (props.isSecure()) {
-      try {
-        securityContext = ArrowheadSecurityContext.createFromProperties();
-      } catch (KeystoreException e) {
-        securityContext = CertificateAuthorityClient.createFromProperties().bootstrap(true);
-      }
-    }
-
+  @Override
+  protected void onStart(ArrowheadSecurityContext securityContext) {
     final ArrowheadServer server = ArrowheadServer.createFromProperties(securityContext);
     server.start(new Class[] { SubscriberResource.class });
 
@@ -42,8 +34,11 @@ class SubscriberMain extends ArrowheadClient {
 
     final EventHandlerClient eventHandler = EventHandlerClient.createFromProperties(securityContext);
     eventHandler.subscribe(props.getEventType(), me);
+  }
 
-    listenForInput();
+  @Override
+  protected void onStop() {
+
   }
 
 }


### PR DESCRIPTION
What do you guys say about Android-like onStart/onStop methods on the clients? The security context is created automatically by the ArrowheadClient class and provided to the onStart().

Its behaviour can either be controlled with bootstrap=true/false in the configuration or by calling the set*() methods on ArrowheadClient before calling start().