### PR TITLE
Bugfix: incorrect subscription URI when unsubscribing.

### DIFF
--- a/client-common/src/main/java/eu/arrowhead/common/api/clients/core/EventHandlerClient.java
+++ b/client-common/src/main/java/eu/arrowhead/common/api/clients/core/EventHandlerClient.java
@@ -137,7 +137,7 @@ public class EventHandlerClient extends HttpClient {
     public void unsubscribe(ArrowheadSystem consumer, String eventType) {
         String consumerName = consumer.getSystemName();
 
-        request(Method.DELETE, SUBSCRIPTION_URI.clone().path("subscription").path("type").path(eventType).path("consumer").path(consumerName));
+        request(Method.DELETE, SUBSCRIPTION_URI.clone().path("type").path(eventType).path("consumer").path(consumerName));
 
         final Map<ArrowheadSystem, Set<String>> handlerSubscriptions = subscriptions.get(this);
         final Set<String> consumerSubscriptions = handlerSubscriptions != null ? handlerSubscriptions.get(consumer) : null;


### PR DESCRIPTION
Unsubscribing without the fix results in a path with 2 times "subscription" in the URI (so "subscription/subscription/type/<eventtype>/consumer<consumername>" whereas it should be "subscription/type/<eventtype>/consumer<consumername>").

This can be verified by running the "client-demo-subscriber" project (from the sos-examples).
When running that example and then quit the subscriber application will result in the following exception:

```
Exception in thread "Thread-0" eu.arrowhead.common.exception.ArrowheadRuntimeException: eventhandler/subscription/subscription/type/hello/consumer/client-demo-subscriber is not a valid path!
        at eu.arrowhead.common.api.clients.HttpClient.check(HttpClient.java:206)
        at eu.arrowhead.common.api.clients.HttpClient.send(HttpClient.java:152)
        at eu.arrowhead.common.api.clients.OrchestrationStrategy.send(OrchestrationStrategy.java:70)
        at eu.arrowhead.common.api.clients.OrchestrationStrategy$Never.request(OrchestrationStrategy.java:103)
        at eu.arrowhead.common.api.clients.HttpClient.request(HttpClient.java:115)
        at eu.arrowhead.common.api.clients.HttpClient.request(HttpClient.java:95)
        at eu.arrowhead.common.api.clients.core.EventHandlerClient.unsubscribe(EventHandlerClient.java:140)
        at eu.arrowhead.common.api.clients.core.EventHandlerClient.lambda$unsubscribe$0(EventHandlerClient.java:155)
        at java.lang.Iterable.forEach(Iterable.java:75)
        at eu.arrowhead.common.api.clients.core.EventHandlerClient.unsubscribe(EventHandlerClient.java:155)
        at java.util.HashMap.forEach(HashMap.java:1289)
        at eu.arrowhead.common.api.clients.core.EventHandlerClient.unsubscribe(EventHandlerClient.java:163)
        at java.util.HashMap.forEach(HashMap.java:1289)
        at eu.arrowhead.common.api.clients.core.EventHandlerClient.unsubscribeAll(EventHandlerClient.java:171)
        at eu.arrowhead.common.api.ArrowheadApplication.lambda$start$0(ArrowheadApplication.java:172)
        at java.lang.Thread.run(Thread.java:748)
```